### PR TITLE
Misc updates

### DIFF
--- a/gec_push
+++ b/gec_push
@@ -6,4 +6,7 @@ readonly filepath="$1"
 readonly filename="$(basename "${filepath}")"
 readonly sj_prefix='sj://test'
 
-echo test-write | xargs -t uplink cp "${filepath}" "${sj_prefix}/${filename}" --access | sed -E 's/^Created //'
+echo test-write \
+  | xargs -t uplink cp "${filepath}" "${sj_prefix}/${filename}" --progress=false --access \
+  | sed -E 's/^Created //' \
+  && ( echo "${filepath}" | xargs -t >&2 rm -fv -- ) # Remove the temp file if it made it up.

--- a/gec_run
+++ b/gec_run
@@ -2,11 +2,18 @@
 
 set -euo pipefail
 
-git_events_collector > /dev/null || nimble build
+readonly url_base="${DW_INGEST_URL:-localhost:8080}"
+readonly ingest_url_template="${url_base}"'/sqlite?sj_path={}&store=git-events'
 
-readonly ingest_url="${DW_INGEST_URL:=localhost:8080}"'/sqlite?sj_path={}&store=git-events'
+readonly sj_path="$(
+  gec_rotate \
+    | xargs -t gec_tsv-to-sqlite \
+    | xargs -t gec_push \
+)"
 
-gec_rotate \
-  | xargs -t gec_tsv-to-sqlite \
-  | xargs -t gec_push \
-  | xargs -t -I{} curl "${ingest_url}"
+if [ "${sj_path}" != '' ]; then
+  # Temporary: May need to wake up what's currently a free-tier Heroku dyno
+  until echo "${url_base}/wake" | xargs -t curl -q -I; do sleep 2; done
+
+  echo "${sj_path}" | xargs -t -I{} curl "${ingest_url_template}"
+fi

--- a/mvp.sh
+++ b/mvp.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+git_events_collector > /dev/null || nimble build
+
 readonly repo_dir="$(realpath -e "${0}" | xargs dirname)"
 
 >&2 echo -e "Running with ${repo_dir} at front of \$PATH...\n"


### PR DESCRIPTION
Changes:

- gec_push:
    - cleans up the local tempfile after it finishes
    - progress output now suppressed; this got messy in launchd logs

- gec_run:
    - now assumes git_events_collector is there; instead, mvp.sh now
      does the check and does a build if that fails
    - sends a "wake" request first (things don't go so great if the Heroku
      dyno is asleep)