### PR TITLE
Handle `0.1.0` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Properly handle loading old (`0.1.0`) events; where remote is not present (https://github.com/awseward/git-events-collector/pull/59)
 
 ## [0.4.0] 2021-12-10
 ### Changed

--- a/src/git_events_collectorpkg/submodule.nim
+++ b/src/git_events_collectorpkg/submodule.nim
@@ -19,13 +19,19 @@ proc parseUtcISO(input: string): DateTime =
 
 proc fromLine(line: string): Event =
   let parts = split(line, "\t")
+  let version = parts[0]
   Event(
-    version: parts[0],
+    version: version,
     timestamp: parseUtcISO(parts[1]),
     hook: parts[2],
     repo: parts[3],
     `ref`: parts[4],
-    remote: parts[5]
+    remote: (
+      if version == "0.1.0":
+        ""
+      else:
+        parts[5]
+    )
   )
 
 proc fromFile*(path: string): seq[Event] =


### PR DESCRIPTION
In other words, don't expect a remote where there definitely won't be one…

There's probably a more "idiomatic" way to write this but I don't use this language often enough for it to come naturally and don't feel like looking it up at the moment.

This probably warrants/warranted a test of some kind. 🤷‍♂️